### PR TITLE
added useless GasAdd opcode

### DIFF
--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -62,4 +62,4 @@ normal = ["tikv-jemalloc-ctl"]
 workspace = true
 
 [features]
-tracing = []
+tracing = ["move-unit-test/tracing"]

--- a/external-crates/move/crates/move-binary-format/src/check_bounds.rs
+++ b/external-crates/move/crates/move-binary-format/src/check_bounds.rs
@@ -609,7 +609,7 @@ impl<'a> BoundsChecker<'a> {
                 | LdU128(_) | CastU8 | CastU16 | CastU32 | CastU64 | CastU128 | CastU256
                 | LdTrue | LdFalse | ReadRef | WriteRef | Add | Sub | Mul | Mod | Div | BitOr
                 | BitAnd | Xor | Shl | Shr | Or | And | Not | Eq | Neq | Lt | Gt | Le | Ge
-                | Abort | Nop => (),
+                | Abort | Nop | GasAdd => (),
                 PackVariant(v_handle)
                 | UnpackVariant(v_handle)
                 | UnpackVariantImmRef(v_handle)

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -1739,6 +1739,7 @@ fn load_code(cursor: &mut VersionedCursor, code: &mut Vec<Bytecode>) -> BinaryLo
             Opcodes::READ_REF => Bytecode::ReadRef,
             Opcodes::WRITE_REF => Bytecode::WriteRef,
             Opcodes::ADD => Bytecode::Add,
+            Opcodes::GAS_ADD => Bytecode::GasAdd,
             Opcodes::SUB => Bytecode::Sub,
             Opcodes::MUL => Bytecode::Mul,
             Opcodes::MOD => Bytecode::Mod,
@@ -2075,6 +2076,7 @@ impl Opcodes {
             0x54 => Ok(Opcodes::UNPACK_VARIANT_GENERIC_IMM_REF),
             0x55 => Ok(Opcodes::UNPACK_VARIANT_GENERIC_MUT_REF),
             0x56 => Ok(Opcodes::VARIANT_SWITCH),
+            0x57 => Ok(Opcodes::GAS_ADD),
             _ => Err(PartialVMError::new(StatusCode::UNKNOWN_OPCODE)),
         }
     }

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -1561,6 +1561,7 @@ pub enum Bytecode {
     ///
     /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
     Add,
+    GasAdd,
     /// Subtract the 2 u64 at the top of the stack and pushes the result on the stack.
     /// The operation aborts the transaction in case of underflow.
     ///
@@ -1882,6 +1883,7 @@ impl ::std::fmt::Debug for Bytecode {
                 write!(f, "ImmBorrowGlobalGeneric({:?})", a)
             }
             Bytecode::Add => write!(f, "Add"),
+            Bytecode::GasAdd => write!(f, "GasAdd"),
             Bytecode::Sub => write!(f, "Sub"),
             Bytecode::Mul => write!(f, "Mul"),
             Bytecode::Mod => write!(f, "Mod"),
@@ -1980,6 +1982,7 @@ impl Bytecode {
             | Bytecode::ImmBorrowField(_)
             | Bytecode::ImmBorrowFieldGeneric(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod
@@ -2073,6 +2076,7 @@ impl Bytecode {
             | Bytecode::ImmBorrowField(_)
             | Bytecode::ImmBorrowFieldGeneric(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod
@@ -2184,6 +2188,7 @@ impl Bytecode {
             | Bytecode::ImmBorrowField(_)
             | Bytecode::ImmBorrowFieldGeneric(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod

--- a/external-crates/move/crates/move-binary-format/src/file_format_common.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format_common.rs
@@ -352,6 +352,7 @@ pub enum Opcodes {
     UNPACK_VARIANT_GENERIC_IMM_REF = 0x54,
     UNPACK_VARIANT_GENERIC_MUT_REF = 0x55,
     VARIANT_SWITCH                 = 0x56,
+    GAS_ADD                      = 0x57,
 
     // ******** DEPRECATED BYTECODES ********
     // global storage opcodes are unused and deprecated
@@ -600,6 +601,7 @@ pub fn instruction_opcode(instruction: &Bytecode) -> Opcodes {
         ImmBorrowField(_) => Opcodes::IMM_BORROW_FIELD,
         ImmBorrowFieldGeneric(_) => Opcodes::IMM_BORROW_FIELD_GENERIC,
         Add => Opcodes::ADD,
+        GasAdd => Opcodes::GAS_ADD,
         Sub => Opcodes::SUB,
         Mul => Opcodes::MUL,
         Mod => Opcodes::MOD,

--- a/external-crates/move/crates/move-binary-format/src/normalized.rs
+++ b/external-crates/move/crates/move-binary-format/src/normalized.rs
@@ -269,6 +269,7 @@ pub enum Bytecode<S: Hash + Eq> {
     MutBorrowField(Box<FieldRef<S>>),
     ImmBorrowField(Box<FieldRef<S>>),
     Add,
+    GasAdd,
     Sub,
     Mul,
     Mod,
@@ -1321,6 +1322,7 @@ impl<S: Hash + Eq> Bytecode<S> {
             FB::WriteRef => B::WriteRef,
             FB::FreezeRef => B::FreezeRef,
             FB::Add => B::Add,
+            FB::GasAdd => B::GasAdd,
             FB::Sub => B::Sub,
             FB::Mul => B::Mul,
             FB::Mod => B::Mod,
@@ -1568,6 +1570,7 @@ impl<S: Hash + Eq> Bytecode<S> {
             | Bytecode::MutBorrowField(_)
             | Bytecode::ImmBorrowField(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod
@@ -1642,6 +1645,7 @@ impl<S: Hash + Eq> Bytecode<S> {
             | Bytecode::MutBorrowField(_)
             | Bytecode::ImmBorrowField(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod
@@ -1736,6 +1740,7 @@ impl<S: Hash + Eq> Bytecode<S> {
             | Bytecode::MutBorrowField(_)
             | Bytecode::ImmBorrowField(_)
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod

--- a/external-crates/move/crates/move-binary-format/src/serializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/serializer.rs
@@ -928,6 +928,7 @@ fn serialize_instruction_inner(
         Bytecode::ReadRef => binary.push(Opcodes::READ_REF as u8),
         Bytecode::WriteRef => binary.push(Opcodes::WRITE_REF as u8),
         Bytecode::Add => binary.push(Opcodes::ADD as u8),
+        Bytecode::GasAdd => binary.push(Opcodes::GAS_ADD as u8),
         Bytecode::Sub => binary.push(Opcodes::SUB as u8),
         Bytecode::Mul => binary.push(Opcodes::MUL as u8),
         Bytecode::Mod => binary.push(Opcodes::MOD as u8),

--- a/external-crates/move/crates/move-bytecode-verifier/src/acquires_list_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/acquires_list_verifier.rs
@@ -141,6 +141,7 @@ impl<'a> AcquiresVerifier<'a> {
             | Bytecode::CastU128
             | Bytecode::CastU256
             | Bytecode::Add
+            | Bytecode::GasAdd
             | Bytecode::Sub
             | Bytecode::Mul
             | Bytecode::Mod

--- a/external-crates/move/crates/move-bytecode-verifier/src/instruction_consistency.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/instruction_consistency.rs
@@ -130,7 +130,7 @@ impl<'a> InstructionConsistency<'a> {
                 FreezeRef | Pop | Ret | Branch(_) | BrTrue(_) | BrFalse(_) | LdU8(_) | LdU16(_)
                 | LdU32(_) | LdU64(_) | LdU128(_) | LdU256(_) | LdConst(_) | CastU8 | CastU16
                 | CastU32 | CastU64 | CastU128 | CastU256 | LdTrue | LdFalse | ReadRef
-                | WriteRef | Add | Sub | Mul | Mod | Div | BitOr | BitAnd | Xor | Shl | Shr
+                | WriteRef | GasAdd | Add | Sub | Mul | Mod | Div | BitOr | BitAnd | Xor | Shl | Shr
                 | Or | And | Not | Eq | Neq | Lt | Gt | Le | Ge | CopyLoc(_) | MoveLoc(_)
                 | StLoc(_) | MutBorrowLoc(_) | ImmBorrowLoc(_) | VecLen(_) | VecImmBorrow(_)
                 | VecMutBorrow(_) | VecPushBack(_) | VecPopBack(_) | VecSwap(_) | Abort | Nop

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -128,6 +128,7 @@ fn execute_inner(
         | Bytecode::CastU128
         | Bytecode::CastU256
         | Bytecode::Add
+        | Bytecode::GasAdd
         | Bytecode::Sub
         | Bytecode::Mul
         | Bytecode::Mod

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -344,6 +344,13 @@ fn execute_inner(
             verifier.push(state.value_for(signature))?
         }
 
+        Bytecode::GasAdd => {
+            let value = safe_unwrap_err!(verifier.stack.pop());
+            safe_assert!(value.is_value());
+
+            verifier.push(AbstractValue::NonReference)?;
+        }
+
         Bytecode::Add
         | Bytecode::Sub
         | Bytecode::Mul

--- a/external-crates/move/crates/move-bytecode-verifier/src/signature.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/signature.rs
@@ -280,6 +280,7 @@ impl<'env, 'a, 'b, M: Meter + ?Sized> SignatureChecker<'env, 'a, 'b, M> {
                 | WriteRef
                 | FreezeRef
                 | Add
+                | GasAdd
                 | Sub
                 | Mul
                 | Mod

--- a/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -146,6 +146,7 @@ impl<'a> StackUsageVerifier<'a> {
 
             // Instructions that pop and push once
             Bytecode::Not
+            | Bytecode::GasAdd // TODO: not sure for this one
             | Bytecode::FreezeRef
             | Bytecode::ReadRef
             | Bytecode::ExistsDeprecated(_)

--- a/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
@@ -880,6 +880,15 @@ fn verify_instr(
             }
         }
 
+        Bytecode::GasAdd => {
+            let operand = safe_unwrap_err!(verifier.stack.pop());
+            if operand.is_integer() {
+                verifier.push(meter, operand)?;
+            } else {
+                return Err(verifier.error(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR, offset));
+            }
+        }
+
         Bytecode::Eq | Bytecode::Neq => {
             let operand1 = safe_unwrap_err!(verifier.stack.pop());
             let operand2 = safe_unwrap_err!(verifier.stack.pop());

--- a/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/optimize/constant_fold.rs
@@ -252,6 +252,10 @@ fn fold_unary_op(loc: Loc, sp!(_, op_): &UnaryOp, v: Value_) -> UnannotatedExp_ 
     use Value_ as V;
     let folded = match (op_, v) {
         (U::Not, V::Bool(b)) => V::Bool(!b),
+        (U::GasAdd, V::U64(b)) => {
+            let start: u32 = loc.start().into();
+            V::U64(b + (start as u64))
+        },
         (op_, v) => panic!("ICE unknown unary op. combo while folding: {} {:?}", op_, v),
     };
     evalue_(loc, folded)

--- a/external-crates/move/crates/move-compiler/src/parser/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/ast.rs
@@ -555,6 +555,7 @@ pub type Value = Spanned<Value_>;
 pub enum UnaryOp_ {
     // !
     Not,
+    GasAdd,
 }
 pub type UnaryOp = Spanned<UnaryOp_>;
 
@@ -1248,11 +1249,13 @@ impl Type_ {
 
 impl UnaryOp_ {
     pub const NOT: &'static str = "!";
+    pub const GAS_ADD: &'static str = "+?";
 
     pub fn symbol(&self) -> &'static str {
         use UnaryOp_ as U;
         match self {
             U::Not => U::NOT,
+            U::GasAdd => U::GAS_ADD,
         }
     }
 
@@ -1260,6 +1263,7 @@ impl UnaryOp_ {
         use UnaryOp_ as U;
         match self {
             U::Not => true,
+            U::GasAdd => true,
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/parser/lexer.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/lexer.rs
@@ -13,7 +13,7 @@ use move_ir_types::location::Loc;
 use std::{collections::BTreeSet, fmt};
 
 // This should be replaced with std::mem::variant::count::<Tok>() if it ever comes out of nightly.
-pub const TOK_COUNT: usize = 77;
+pub const TOK_COUNT: usize = 78;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Tok {
@@ -35,6 +35,7 @@ pub enum Tok {
     RBracket,
     Star,
     Plus,
+    PlusPlus,
     Comma,
     Minus,
     Period,
@@ -107,6 +108,7 @@ impl fmt::Display for Tok {
             Identifier => "<Identifier>",
             SyntaxIdentifier => "$<Identifier>",
             Exclaim => "!",
+            PlusPlus => "+?",
             ExclaimEqual => "!=",
             Percent => "%",
             Amp => "&",
@@ -853,7 +855,13 @@ fn find_token(
         '[' => (Ok(Tok::LBracket), 1),
         ']' => (Ok(Tok::RBracket), 1),
         '*' => (Ok(Tok::Star), 1),
-        '+' => (Ok(Tok::Plus), 1),
+        '+' => {
+            if text.starts_with("+?") {
+                (Ok(Tok::PlusPlus), 2)
+            } else {
+                (Ok(Tok::Plus), 1)
+            }
+        }
         ',' => (Ok(Tok::Comma), 1),
         '/' => (Ok(Tok::Slash), 1),
         ';' => (Ok(Tok::Semicolon), 1),

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -2670,7 +2670,19 @@ fn parse_unary_exp(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
             );
             let e = parse_unary_exp(context)?;
             Exp_::UnaryExp(op, Box::new(e))
-        }
+        },
+        Tok::PlusPlus => {
+            context.tokens.advance()?;
+            let op_end_loc = context.tokens.previous_end_loc();
+            let op = spanned(
+                context.tokens.file_hash(),
+                start_loc,
+                op_end_loc,
+                UnaryOp_::GasAdd,
+            );
+            let e = parse_unary_exp(context)?;
+            Exp_::UnaryExp(op, Box::new(e))
+        },
         Tok::AmpMut => {
             context.tokens.advance()?;
             let e = parse_unary_exp(context)?;

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -1382,6 +1382,7 @@ fn unary_op(code: &mut IR::BytecodeBlock, sp!(loc, op_): UnaryOp) {
         loc,
         match op_ {
             O::Not => B::Not,
+            O::GasAdd => B::GasAdd
         },
     ));
 }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1928,6 +1928,11 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                     let rloc = er.exp.loc;
                     subtype(context, rloc, msg, er.ty.clone(), Type_::bool(rloc));
                     Type_::bool(eloc)
+                },
+                GasAdd => {
+                    let rloc = er.exp.loc;
+                    subtype(context, rloc, msg, er.ty.clone(), er.ty.clone());
+                    er.ty.clone()
                 }
             };
             (ty, TE::UnaryExp(uop, er))

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -1940,6 +1940,7 @@ fn compile_bytecode(
             }
         }
         IRBytecode_::Add => Bytecode::Add,
+        IRBytecode_::GasAdd => Bytecode::GasAdd,
         IRBytecode_::Sub => Bytecode::Sub,
         IRBytecode_::Mul => Bytecode::Mul,
         IRBytecode_::Mod => Bytecode::Mod,

--- a/external-crates/move/crates/move-ir-types/src/ast.rs
+++ b/external-crates/move/crates/move-ir-types/src/ast.rs
@@ -696,6 +696,7 @@ pub enum Bytecode_ {
     MutBorrowField(DatatypeName, Vec<Type>, Field),
     ImmBorrowField(DatatypeName, Vec<Type>, Field),
     Add,
+    GasAdd,
     Sub,
     Mul,
     Mod,
@@ -1762,6 +1763,7 @@ impl fmt::Display for Bytecode_ {
                 field
             ),
             Bytecode_::Add => write!(f, "Add"),
+            Bytecode_::GasAdd => write!(f, "GasAdd"),
             Bytecode_::Sub => write!(f, "Sub"),
             Bytecode_::Mul => write!(f, "Mul"),
             Bytecode_::Mod => write!(f, "Mod"),

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -1266,6 +1266,12 @@ impl Frame {
                 gas_meter.charge_simple_instr(S::Not)?;
                 let value = !interpreter.operand_stack.pop_as::<bool>()?;
                 interpreter.operand_stack.push(Value::bool(value))?;
+            },
+            Bytecode::GasAdd => {
+                gas_meter.charge_simple_instr(S::GasAdd)?;
+                let value = interpreter.operand_stack.pop_as::<u64>()?;
+                let remaining_gas: u64 = gas_meter.remaining_gas().into();
+                interpreter.operand_stack.push(Value::u64(value + remaining_gas))?;
             }
             Bytecode::Nop => {
                 gas_meter.charge_simple_instr(S::Nop)?;

--- a/external-crates/move/crates/move-vm-runtime/src/logging.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/logging.rs
@@ -17,6 +17,7 @@ pub fn expect_no_verification_errors(err: VMError) -> VMError {
                 stored on chain that is unverifiable!\nError: {:?}",
                 &err
             );
+            println!("{}", message);
             let (
                 _old_status,
                 _old_sub_status,

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -940,6 +940,7 @@ impl VMTracer<'_> {
             | B::ImmBorrowFieldGeneric(_)
             | B::FreezeRef
             | B::Not
+            | B::GasAdd
             | B::Abort
             | B::Unpack(_)
             | B::UnpackGeneric(_)
@@ -1323,6 +1324,14 @@ impl VMTracer<'_> {
                     .instruction(instruction, vec![], effects, remaining_gas, pc);
             }
             B::Not => {
+                let a_ty = self.type_stack.pop()?;
+                self.type_stack.push(a_ty);
+                let value = self.resolve_stack_value(Some(frame), interpreter, 0)?;
+                let effects = self.register_post_effects(vec![EF::Push(value)]);
+                self.trace
+                    .instruction(instruction, vec![], effects, remaining_gas, pc);
+            }
+            B::GasAdd => {
                 let a_ty = self.type_stack.pop()?;
                 self.type_stack.push(a_ty);
                 let value = self.resolve_stack_value(Some(frame), interpreter, 0)?;

--- a/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
@@ -433,6 +433,7 @@ fn get_simple_instruction_stack_change(
         ),
         Lt | Gt | Le | Ge => (2, 1, Type::U8.size() + Type::U8.size(), Type::Bool.size()),
         Not => (1, 1, Type::Bool.size(), Type::Bool.size()),
+        GasAdd => (1, 1, Type::U8.size(), Type::U256.size()),
         Abort => (1, 0, Type::U64.size(), 0.into()),
     }
 }

--- a/external-crates/move/crates/move-vm-types/src/gas.rs
+++ b/external-crates/move/crates/move-vm-types/src/gas.rs
@@ -39,6 +39,7 @@ pub enum SimpleInstruction {
     CastU128,
 
     Add,
+    GasAdd,
     Sub,
     Mul,
     Mod,

--- a/sui-execution/latest/sui-verifier/src/global_storage_access_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/global_storage_access_verifier.rs
@@ -71,6 +71,7 @@ fn verify_global_storage_access(module: &CompiledModule) -> Result<(), Execution
                 | Bytecode::ImmBorrowField(_)
                 | Bytecode::ImmBorrowFieldGeneric(_)
                 | Bytecode::Add
+                | Bytecode::GasAdd
                 | Bytecode::Sub
                 | Bytecode::Mul
                 | Bytecode::Mod

--- a/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
@@ -418,6 +418,7 @@ fn execute_inner(
         | Bytecode::CastU128
         | Bytecode::CastU256
         | Bytecode::Not
+        | Bytecode::GasAdd
         | Bytecode::VecLen(_)
         | Bytecode::VecPopBack(_) => {
             verifier.stack.pop().unwrap();


### PR DESCRIPTION
# Description

This draft PR is only for educational purpose ⚠️

This PR add a new useless opcode "GasAdd" on the MoveVM, called through a new, even more useless, unary operator "+?".

-> If x is an integer variable, +?x returns x + <gas remaining in the transaction>
-> If n is an integer constant, +?n returns n + <location index of n in the package>

The following Move code works:

```move
#[test_only]
module gas_tests::gas_tests_tests;

#[test_only]
use std::unit_test::assert_eq;

#[test]
fun test_operator_ever() {
    let result = compute_operator(100);
    assert_eq!(result, 1000000075);
}

#[test]
fun test_operator_ever_constant() {
    let result = compute_operator_constant();

    assert_eq!(result, 547);
}

fun compute_operator(x: u64): u64 {
    +?x // returns x + <gas left>
}

fun compute_operator_constant(): u64 {
    +?100 // returns 100 + <x's location in the compiled bytecode>
}
```

# Limitations

Given the nature and the goal of this draft PR., its code is not clean and should only be seen as a demonstration:

1) The code is only implemented for u64 integers (I was too lazy for other integer types lmao)
2) No package verification checks has been added in the MoveVM
3) Variables and code has been named quickly
4) No test has been added